### PR TITLE
Fix/button group alignment

### DIFF
--- a/packages/react/src/components/ButtonGroup/ButtonGroup.js
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup.js
@@ -38,12 +38,19 @@ const ButtonGroup = ({ buttons, enableSizeByContent }) => {
               (acc, item) => Math.max(acc, item.offsetWidth),
               0
             );
+            const height = Array.prototype.reduce.call(
+              group.querySelectorAll('.bx--buttongroup-item--pseudo .bx--btn'),
+              (acc, item) => Math.max(acc, item.offsetHeight),
+              0
+            );
+            const hasWordWrap = height > 48;
             Array.prototype.forEach.call(
               group.querySelectorAll(
                 '.bx--buttongroup-item:not(.bx--buttongroup-item--pseudo) .bx--btn'
               ),
               item => {
                 item.style.width = `${width + 1}px`;
+                item.classList.toggle(`${prefix}--btn--multiline`, hasWordWrap);
               }
             );
           });

--- a/packages/styles/scss/components/buttongroup/_buttongroup.scss
+++ b/packages/styles/scss/components/buttongroup/_buttongroup.scss
@@ -21,8 +21,6 @@
     }
 
     .#{$prefix}--btn {
-      display: inline-block;
-      line-height: normal;
       font-size: 1rem;
       position: relative;
       width: 100%;
@@ -31,10 +29,13 @@
       transition: all $duration--fast-01 motion(entrance, productive), width 0s,
         height 0s;
       &__icon {
-        top: $carbon--spacing-04;
         width: auto;
         height: auto;
       }
+    }
+
+    .#{$prefix}--btn--multiline {
+      align-items: start;
     }
   }
 


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/ibm-dotcom-library/pull/2785

### Description

Leverage `ResizeObserver` in `ButtonGroup` to get button heights. If greater than minimum height (`48px`) add multi-line styles for top alignment.

### Changelog

**New**

- check for height value in `ButtonGroup`
- styles for top-alignment when buttons are greater than default height


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React, React (experimental) -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities" Utilities -->
<!-- *** "package: styles" Carbon Expressive, React (Expressive) -->
<!-- *** "RTL" React (RTL) -->
