### PR TITLE
fix(CardGroup): fix sameHeight class names

### DIFF
--- a/packages/react/src/components/CardGroup/CardGroup.js
+++ b/packages/react/src/components/CardGroup/CardGroup.js
@@ -37,13 +37,13 @@ const CardGroup = ({ cards, cta }) => {
       if (containerNode) {
         sameHeight(
           containerNode.getElementsByClassName(
-            `:not(${prefix}--card__video) ${prefix}--card__heading`
+            `:not(.${prefix}--card__video) ${prefix}--card__heading`
           ),
           'md'
         );
         sameHeight(
           containerNode.getElementsByClassName(
-            `:not(${prefix}--card__video) ${prefix}--card__copy`
+            `:not(.${prefix}--card__video) ${prefix}--card__copy`
           ),
           'md'
         );
@@ -53,10 +53,6 @@ const CardGroup = ({ cards, cta }) => {
         );
         sameHeight(
           containerNode.getElementsByClassName(`${prefix}--card--link`),
-          'md'
-        );
-        sameHeight(
-          containerNode.getElementsByClassName(`${prefix}--card`),
           'md'
         );
       }

--- a/packages/styles/scss/components/card-group/_card-group.scss
+++ b/packages/styles/scss/components/card-group/_card-group.scss
@@ -90,6 +90,10 @@
 
         margin-top: $carbon--grid-gutter--condensed / 2;
         margin-bottom: $carbon--grid-gutter--condensed / 2;
+
+        .#{$prefix}--card--inverse {
+          height: 100%;
+        }
       }
     }
     @include themed-items;


### PR DESCRIPTION
### Description

Fix `sameHeight` for card components

### Changelog

**Changed**

- add 100% height for CTA card
- update `sameHeight` class names


<!-- Deploy Previews are enabled by applying the following labels for the corresponding package: -->
<!-- *** "package: react": React -->
<!-- *** "package: web components": Web Components -->
<!-- *** "package: vanilla": Vanilla -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "package: styles": Carbon Expressive, React (Expressive) -->
<!-- *** "RTL": React (RTL) -->
<!-- *** "feature flag": React (experimental) -->
