### PR TITLE
chore(webpack): change terser minify options

### DIFF
--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -83,9 +83,10 @@ module.exports = {
       },
       minimizer: [
         new TerserPlugin({
+          minify: TerserPlugin.esbuildMinify,
           sourceMap: useStyleSourceMap,
           terserOptions: {
-            mangle: false,
+            minify: true,
           },
         }),
       ],

--- a/packages/web-components/.storybook/main.js
+++ b/packages/web-components/.storybook/main.js
@@ -61,9 +61,10 @@ module.exports = {
       },
       minimizer: [
         new TerserPlugin({
+          minify: TerserPlugin.esbuildMinify,
           sourceMap: useStyleSourceMap,
           terserOptions: {
-            mangle: false,
+            minify: true,
           },
         }),
       ],


### PR DESCRIPTION
### Description

Modify Webpack terser options to lower `storybook-static` output size. This is an attempt to lower Storybook static filesizes as much as possible to avoid Percy timeout errors.

`web-components`
before
![wc-orig](https://user-images.githubusercontent.com/909118/189710894-b6098210-319a-41f5-b9e1-e7d2562b9eda.png)

after
![wc-esbuildMinify](https://user-images.githubusercontent.com/909118/189711008-01140af6-4126-44ba-a53b-f64062033cd9.png)

`react`
before
![react-orig](https://user-images.githubusercontent.com/909118/189711049-b5641455-d6bb-4fd1-b149-d643cea4cf83.png)

after
![react-esbuildMinify](https://user-images.githubusercontent.com/909118/189711060-e0b02a08-1c83-4552-9ef7-b8dab4b73361.png)


### Changelog

**Changed**

- update React and web components Storybook Webpack options to use `esbuildMinify` compression with terser



<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
